### PR TITLE
New action for add or change password for the OV

### DIFF
--- a/som_users/__init__.py
+++ b/som_users/__init__.py
@@ -1,1 +1,2 @@
 import users
+import wizard

--- a/som_users/__terp__.py
+++ b/som_users/__terp__.py
@@ -11,12 +11,15 @@
         "base_extended",
         "partner_representante",
         "som_signed_documents",
+        "poweremail",
     ],
     "init_xml": [],
     "demo_xml": [
         "demo/res_partner_demo.xml",
     ],
     "update_xml":[
+        "wizard/wizard_create_change_password_view.xml",
+        "data/email_template_data.xml",
         "security/ir.model.access.csv",
     ],
     "active": False,

--- a/som_users/data/email_template_data.xml
+++ b/som_users/data/email_template_data.xml
@@ -15,7 +15,7 @@
             <field name="object_name" model="ir.model" search="[('name', '=', 'Partner')]"/>
             <field eval="0" name="save_to_drafts"/>
             <field name="model_int_name">res.partner</field>
-            <field name="def_to">${object.address[0].email},${object.address[0].email}</field>
+            <field name="def_to">${object.address[0].email}</field>
             <field eval="0" name="auto_email"/>
             <field eval="0" name="single_email"/>
             <field eval="0" name="use_sign"/>

--- a/som_users/data/email_template_data.xml
+++ b/som_users/data/email_template_data.xml
@@ -19,7 +19,7 @@
             <field eval="0" name="auto_email"/>
             <field eval="0" name="single_email"/>
             <field eval="0" name="use_sign"/>
-            <field name="def_subject">Modificació de contrassenya ${object.name}</field>
+            <field name="def_subject">Recuperació de la contrasenya de l’Oficina Virtual de representació a mercat de Som Energia</field>
             <field name="template_language">mako</field>
             <field eval="0" name="send_on_create"/>
             <field name="lang">${object.lang}</field>
@@ -37,5 +37,32 @@
                 ]]>
             </field>
     	</record>
+        <record model="poweremail.templates" id="common_template_legal_footer_representa">
+            <field name="name">Common template legal footer representa</field>
+            <field name="object_name" model="ir.model" search="[('model', '=', 'poweremail.templates')]"/>
+            <field eval="0" name="save_to_drafts"/>
+            <field name="model_int_name">poweremail.templates</field>
+            <field name="def_to">""</field>
+            <field name="def_bcc"></field>
+            <field eval="0" name="auto_email"/>
+            <field eval="0" name="single_email"/>
+            <field eval="0" name="use_sign"/>
+            <field name="def_subject"></field>
+            <field name="template_language">mako</field>
+            <field eval="0" name="send_on_create"/>
+            <field name="lang"></field>
+            <field name="copyvalue"></field>
+            <field eval="0" name="send_on_write"/>
+            <field name="def_body_text"><![CDATA[<!doctype html>
+                <!doctype html>
+                <html>
+                <head></head>
+                <body>
+                Footer representa text
+                </body>
+                </html>
+                ]]>
+            </field>
+        </record>
     </data>
 </openerp>

--- a/som_users/data/email_template_data.xml
+++ b/som_users/data/email_template_data.xml
@@ -24,7 +24,7 @@
             <field eval="0" name="send_on_create"/>
             <field name="lang">${object.lang}</field>
             <field eval="0" name="send_on_write"/>
-            <field name="def_bcc">support.17062.b8d9f4469fa4d856@helpscout.net</field>
+            <field name="def_bcc"></field>
             <field name="enforce_from_account" model="poweremail.core_accounts" search="[('name','=', 'Som Energia - Representació')]"/>
             <field name="def_body_text"><![CDATA[
                 <!doctype html>

--- a/som_users/data/email_template_data.xml
+++ b/som_users/data/email_template_data.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+        <record model="poweremail.core_accounts" id="representa_from_email">
+            <field name="email_id">info@somenergia.coop</field>
+            <field name="company">yes</field>
+            <field name="smtpserver">test.com</field>
+            <field name="send_pref">html</field>
+            <field name="name">Som Energia - Representació</field>
+            <field name="state">approved</field>
+            <field name="smtpport">587</field>
+        </record>
+        <record model="poweremail.templates" id="email_create_change_password">
+            <field name="name">Email crear o canviar contrassenya</field>
+            <field name="object_name" model="ir.model" search="[('name', '=', 'Partner')]"/>
+            <field eval="0" name="save_to_drafts"/>
+            <field name="model_int_name">res.partner</field>
+            <field name="def_to">${object.address[0].email},${object.address[0].email}</field>
+            <field eval="0" name="auto_email"/>
+            <field eval="0" name="single_email"/>
+            <field eval="0" name="use_sign"/>
+            <field name="def_subject">Modificació de contrassenya ${object.name}</field>
+            <field name="template_language">mako</field>
+            <field eval="0" name="send_on_create"/>
+            <field name="lang">${object.lang}</field>
+            <field eval="0" name="send_on_write"/>
+            <field name="def_bcc">support.17062.b8d9f4469fa4d856@helpscout.net</field>
+            <field name="enforce_from_account" model="poweremail.core_accounts" search="[('name','=', 'Som Energia - Representació')]"/>
+            <field name="def_body_text"><![CDATA[
+                <!doctype html>
+                <html>
+                <head></head>
+                <body>
+                Email text
+                </body>
+                </html>
+                ]]>
+            </field>
+    	</record>
+    </data>
+</openerp>

--- a/som_users/data/email_template_data.xml
+++ b/som_users/data/email_template_data.xml
@@ -11,7 +11,7 @@
             <field name="smtpport">587</field>
         </record>
         <record model="poweremail.templates" id="email_create_change_password">
-            <field name="name">Email crear o canviar contrassenya</field>
+            <field name="name">Email crear o canviar contrasenya</field>
             <field name="object_name" model="ir.model" search="[('name', '=', 'Partner')]"/>
             <field eval="0" name="save_to_drafts"/>
             <field name="model_int_name">res.partner</field>

--- a/som_users/data/email_template_data.xml
+++ b/som_users/data/email_template_data.xml
@@ -2,7 +2,7 @@
 <openerp>
     <data noupdate="1">
         <record model="poweremail.core_accounts" id="representa_from_email">
-            <field name="email_id">info@somenergia.coop</field>
+            <field name="email_id">representa@somenergia.coop</field>
             <field name="company">yes</field>
             <field name="smtpserver">test.com</field>
             <field name="send_pref">html</field>

--- a/som_users/exceptions.py
+++ b/som_users/exceptions.py
@@ -35,3 +35,10 @@ class FailSendEmail(SomUsersException):
             text="Error sending email",
             message=message
         )
+
+class FailSavePassword(SomUsersException):
+    def __init__(self, message):
+        super(FailSavePassword, self).__init__(
+            text="Error saving password",
+            message=message
+        )

--- a/som_users/exceptions.py
+++ b/som_users/exceptions.py
@@ -1,7 +1,8 @@
 class SomUsersException(Exception):
-    def __init__(self, text):
+    def __init__(self, text, message=None):
         self.exc_type = 'error'
         self.text = text
+        self.message = message
         super(SomUsersException, self).__init__(self.text)
 
     @property
@@ -12,6 +13,7 @@ class SomUsersException(Exception):
         return dict(
             code=self.code,
             error=self.text,
+            message=self.message
         )
 
 
@@ -25,4 +27,11 @@ class NoDocumentVersions(SomUsersException):
     def __init__(self, document):
         super(NoDocumentVersions, self).__init__(
             text="Document {} has no version available to sign".format(document)
+            text="Partner does not exist")
+
+class FailSendEmail(SomUsersException):
+    def __init__(self, message):
+        super(FailSendEmail, self).__init__(
+            text="Error sending email",
+            message=message
         )

--- a/som_users/security/ir.model.access.csv
+++ b/som_users/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_partner_rcwd","users","model_users","base.group_user",1,1,1,1
+"access_wizard_create_change_password_rcwd","wizard.create.change.password","model_wizard_create_change_password","base.group_user",1,1,1,1

--- a/som_users/tests/__init__.py
+++ b/som_users/tests/__init__.py
@@ -1,1 +1,2 @@
 from test_som_users import *
+from test_wizard_create_change_password import *

--- a/som_users/tests/test_wizard_create_change_password.py
+++ b/som_users/tests/test_wizard_create_change_password.py
@@ -261,7 +261,7 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
         )
 
         password = 'new_test_password'
-        comment = 'one_comment\ngenerated_ov_password:test_password(today)'
+        comment = 'one_comment\ngenerated_ov_password=test_password(generated_ov_password)\n'
         self.res_partner.write(self.cursor, self.uid, partner_id[0], {'comment':comment})
 
         self.wiz_o.add_password_to_partner_comment(self.cursor, self.uid, partner_id[0], password)

--- a/som_users/tests/test_wizard_create_change_password.py
+++ b/som_users/tests/test_wizard_create_change_password.py
@@ -40,7 +40,7 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
         wiz = self.wiz_o.read(self.cursor, self.uid, [wiz_id])[0]
 
         self.assertEqual(wiz['state'], 'done')
-        self.assertEqual(wiz['info'], 'Contrassenyes generades')
+        self.assertEqual(wiz['info'], 'Contrasenyes generades')
 
     @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.send_password_email")
     @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
@@ -62,9 +62,9 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
 
         self.assertEqual(wiz['state'], 'done')
         self.assertEqual(wiz['info'], '{}: \n {} ({})\n'.format(
-            'Error generant contrassenyes pels següents partners',
+            'Error generant contrasenyes pels següents partners',
             int(partner_id[0]),
-            'Error al guardar la contrasseya'
+            'Error al guardar la contrasenya'
             )
         )
         mock_send_password_email.assert_not_called()
@@ -95,7 +95,7 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
 
         self.assertEqual(wiz['state'], 'done')
         self.assertEqual(wiz['info'], '{}: \n {} ({})\n'.format(
-            'Error generant contrassenyes pels següents partners',
+            'Error generant contrasenyes pels següents partners',
             int(partner_id[0]),
             "Error al generar/enviar l'email")
         )
@@ -118,7 +118,7 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
         wiz = self.wiz_o.read(self.cursor, self.uid, [wiz_id])[0]
 
         self.assertEqual(wiz['state'], 'done')
-        self.assertEqual(wiz['info'], 'Contrassenyes generades')
+        self.assertEqual(wiz['info'], 'Contrasenyes generades')
 
     @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.send_password_email")
     @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
@@ -140,8 +140,8 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
 
         self.assertEqual(wiz['state'], 'done')
         self.assertEqual(wiz['info'], '{}: \n {}'.format(
-            'Error generant contrassenyes pels següents partners',
-            ','.join(['{} ({})\n'.format(str(int(x)),'Error al guardar la contrasseya') for x in partner_ids])
+            'Error generant contrasenyes pels següents partners',
+            ','.join(['{} ({})\n'.format(str(int(x)),'Error al guardar la contrasenya') for x in partner_ids])
             )
         )
 
@@ -170,8 +170,8 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
 
         self.assertEqual(wiz['state'], 'done')
         self.assertEqual(wiz['info'], '{}: \n {}'.format(
-            'Error generant contrassenyes pels següents partners',
-            ','.join(['{} ({})\n'.format(str(int(x)),'Error al guardar la contrasseya') for x in partner_ids if x % 2 == 0])
+            'Error generant contrasenyes pels següents partners',
+            ','.join(['{} ({})\n'.format(str(int(x)),'Error al guardar la contrasenya') for x in partner_ids if x % 2 == 0])
             )
         )
 
@@ -201,7 +201,7 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
 
         self.assertEqual(wiz['state'], 'done')
         self.assertEqual(wiz['info'], '{}: \n {}'.format(
-            'Error generant contrassenyes pels següents partners',
+            'Error generant contrasenyes pels següents partners',
             ','.join(['{} ({})\n'.format(str(int(x)),"Error al generar/enviar l'email") for x in partner_ids if x % 2 == 0])
             )
         )

--- a/som_users/tests/test_wizard_create_change_password.py
+++ b/som_users/tests/test_wizard_create_change_password.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from destral import testing
+from destral.transaction import Transaction
+from som_users.exceptions import FailSendEmail
+
+from som_users.exceptions import FailSendEmail
+
+import mock
+
+class WizardCreateChangePasswordTests(testing.OOTestCase):
+
+    def setUp(self):
+        self.pool = self.openerp.pool
+        self.res_partner = self.pool.get('res.partner')
+        self.wiz_o = self.pool.get('wizard.create.change.password')
+
+        self.txn = Transaction().start(self.database)
+
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+
+    def tearDown(self):
+        self.txn.stop()
+
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
+    def test__action_create_change_password__OK(self, mock_save_password):
+        partner_id = self.res_partner.search(
+            self.cursor,
+            self.uid,
+            [('vat', '=', 'ES48591264S')]
+        )
+
+        context = {'active_ids': partner_id}
+        wiz_id = self.wiz_o.create(self.cursor, self.uid, {}, context=context)
+
+        mock_save_password.return_value = True
+
+        self.wiz_o.action_create_change_password(self.cursor, self.uid, [wiz_id], context=context)
+
+        wiz = self.wiz_o.read(self.cursor, self.uid, [wiz_id])[0]
+
+        self.assertEqual(wiz['state'], 'done')
+        self.assertEqual(wiz['info'], 'Contrassenyes generades')
+
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.send_password_email")
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
+    def test__action_create_change_password__KO_cannot_save_password(self, mock_save_password, mock_send_password_email):
+        partner_id = self.res_partner.search(
+            self.cursor,
+            self.uid,
+            [('vat', '=', 'ES48591264S')]
+        )
+
+        context = {'active_ids': partner_id}
+        wiz_id = self.wiz_o.create(self.cursor, self.uid, {}, context=context)
+
+        mock_save_password.return_value = False
+
+        self.wiz_o.action_create_change_password(self.cursor, self.uid, [wiz_id], context=context)
+
+        wiz = self.wiz_o.read(self.cursor, self.uid, [wiz_id])[0]
+
+        self.assertEqual(wiz['state'], 'done')
+        self.assertEqual(wiz['info'], '{}: \n {} ({})\n'.format(
+            'Error generant contrassenyes pels següents partners',
+            int(partner_id[0]),
+            'Contrassenya no generada'
+            )
+        )
+        mock_send_password_email.assert_not_called()
+
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.send_password_email")
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
+    def test__action_create_change_password__KO_cannot_send_password_email(self, mock_save_password, mock_send_password_email):
+        partner_id = self.res_partner.search(
+            self.cursor,
+            self.uid,
+            [('vat', '=', 'ES48591264S')]
+        )
+
+        context = {'active_ids': partner_id}
+        wiz_id = self.wiz_o.create(self.cursor, self.uid, {}, context=context)
+
+        mock_save_password.return_value = True
+        
+        def send_password_email(cursor, uid, partner_id):
+            raise FailSendEmail('Error text')
+
+        mock_send_password_email.side_effect = send_password_email
+
+        self.wiz_o.action_create_change_password(self.cursor, self.uid, [wiz_id], context=context)
+
+        wiz = self.wiz_o.read(self.cursor, self.uid, [wiz_id])[0]
+
+        self.assertEqual(wiz['state'], 'done')
+        self.assertEqual(wiz['info'], '{}: \n {} ({})\n'.format(
+            'Error generant contrassenyes pels següents partners',
+            int(partner_id[0]),
+            "Error al generar/enviar l'email")
+        )
+
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
+    def test__action_create_change_password__multiple_partners__OK(self, mock_save_password):
+        partner_ids = self.res_partner.search(
+            self.cursor,
+            self.uid,
+            [('active', '=', True)]
+        )
+
+        context = {'active_ids': partner_ids}
+        wiz_id = self.wiz_o.create(self.cursor, self.uid, {}, context=context)
+
+        mock_save_password.return_value = True
+
+        self.wiz_o.action_create_change_password(self.cursor, self.uid, [wiz_id], context=context)
+
+        wiz = self.wiz_o.read(self.cursor, self.uid, [wiz_id])[0]
+
+        self.assertEqual(wiz['state'], 'done')
+        self.assertEqual(wiz['info'], 'Contrassenyes generades')
+
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.send_password_email")
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
+    def test__action_create_change_password__multiple_partners__KO_cannot_save_password(self, mock_save_password, mock_send_password_email):
+        partner_ids = self.res_partner.search(
+            self.cursor,
+            self.uid,
+            [('active', '=', True)]
+        )
+
+        context = {'active_ids': partner_ids}
+        wiz_id = self.wiz_o.create(self.cursor, self.uid, {}, context=context)
+
+        mock_save_password.return_value = False
+
+        self.wiz_o.action_create_change_password(self.cursor, self.uid, [wiz_id], context=context)
+
+        wiz = self.wiz_o.read(self.cursor, self.uid, [wiz_id])[0]
+
+        self.assertEqual(wiz['state'], 'done')
+        self.assertEqual(wiz['info'], '{}: \n {}'.format(
+            'Error generant contrassenyes pels següents partners',
+            ','.join(['{} ({})\n'.format(str(int(x)),'Contrassenya no generada') for x in partner_ids])
+            )
+        )
+
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.send_password_email")
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
+    def test__action_create_change_password__multiple_partners__KO_cannot_save_password__even_partner_id(self, mock_save_password, mock_send_password_email):
+        partner_ids = self.res_partner.search(
+            self.cursor,
+            self.uid,
+            [('active', '=', True)]
+        )
+
+        context = {'active_ids': partner_ids}
+        wiz_id = self.wiz_o.create(self.cursor, self.uid, {}, context=context)
+
+        def save_password(cursor, uid, partner_id, password):
+            if partner_id % 2 == 0:
+                return False
+            return True            
+
+        mock_save_password.side_effect = save_password
+
+        self.wiz_o.action_create_change_password(self.cursor, self.uid, [wiz_id], context=context)
+
+        wiz = self.wiz_o.read(self.cursor, self.uid, [wiz_id])[0]
+
+        self.assertEqual(wiz['state'], 'done')
+        self.assertEqual(wiz['info'], '{}: \n {}'.format(
+            'Error generant contrassenyes pels següents partners',
+            ','.join(['{} ({})\n'.format(str(int(x)),'Contrassenya no generada') for x in partner_ids if x % 2 == 0])
+            )
+        )
+
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.send_password_email")
+    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
+    def test__action_create_change_password__KO_cannot_send_password_email__even_partner_id(self, mock_save_password, mock_send_password_email):
+        partner_ids = self.res_partner.search(
+            self.cursor,
+            self.uid,
+            [('active', '=', True)]
+        )
+
+        context = {'active_ids': partner_ids}
+        wiz_id = self.wiz_o.create(self.cursor, self.uid, {}, context=context)
+
+        mock_save_password.return_value = True
+        
+        def send_password_email(cursor, uid, partner_id):
+            if int(partner_id.id) % 2 == 0:
+                raise FailSendEmail('Error text')
+
+        mock_send_password_email.side_effect = send_password_email
+
+        self.wiz_o.action_create_change_password(self.cursor, self.uid, [wiz_id], context=context)
+
+        wiz = self.wiz_o.read(self.cursor, self.uid, [wiz_id])[0]
+
+        self.assertEqual(wiz['state'], 'done')
+        self.assertEqual(wiz['info'], '{}: \n {}'.format(
+            'Error generant contrassenyes pels següents partners',
+            ','.join(['{} ({})\n'.format(str(int(x)),"Error al generar/enviar l'email") for x in partner_ids if x % 2 == 0])
+            )
+        )

--- a/som_users/tests/test_wizard_create_change_password.py
+++ b/som_users/tests/test_wizard_create_change_password.py
@@ -221,3 +221,51 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
         result = self.wiz_o.save_password(self.cursor, self.uid, partner_id[0], password)
 
         self.assertFalse(result)
+
+    def test__add_password_to_partner_comment__comment_empty(self):
+        partner_id = self.res_partner.search(
+            self.cursor,
+            self.uid,
+            [('vat', '=', 'ES48591264S')]
+        )
+
+        password = 'test-password'
+
+        self.wiz_o.add_password_to_partner_comment(self.cursor, self.uid, partner_id[0], password)
+
+        partner = self.res_partner.browse(self.cursor, self.uid, partner_id[0])
+
+        self.assertTrue('generated_ov_password' in partner.comment)
+
+    def test__add_password_to_partner_comment__comment_not_empty(self):
+        partner_id = self.res_partner.search(
+            self.cursor,
+            self.uid,
+            [('vat', '=', 'ES48591264S')]
+        )
+
+        password = 'test-password'
+        self.res_partner.write(self.cursor, self.uid, partner_id[0], {'comment':'one_comment'})
+
+        self.wiz_o.add_password_to_partner_comment(self.cursor, self.uid, partner_id[0], password)
+
+        partner = self.res_partner.browse(self.cursor, self.uid, partner_id[0])
+
+        self.assertTrue('generated_ov_password' in partner.comment)
+
+    def test__add_password_to_partner_comment__comment_has_generated_password(self):
+        partner_id = self.res_partner.search(
+            self.cursor,
+            self.uid,
+            [('vat', '=', 'ES48591264S')]
+        )
+
+        password = 'new_test_password'
+        comment = 'one_comment\ngenerated_ov_password:test_password(today)'
+        self.res_partner.write(self.cursor, self.uid, partner_id[0], {'comment':comment})
+
+        self.wiz_o.add_password_to_partner_comment(self.cursor, self.uid, partner_id[0], password)
+
+        partner = self.res_partner.browse(self.cursor, self.uid, partner_id[0])
+
+        self.assertTrue('new_test_password' in partner.comment)

--- a/som_users/tests/test_wizard_create_change_password.py
+++ b/som_users/tests/test_wizard_create_change_password.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from destral import testing
 from destral.transaction import Transaction
-from som_users.exceptions import FailSendEmail, FailSavePassword
+from som_users.exceptions import FailSendEmail
 
 import mock
 
@@ -69,35 +69,6 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
         )
         mock_send_password_email.assert_not_called()
 
-    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.send_password_email")
-    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
-    def test__action_create_change_password__KO_cannot_save_password_with_exception(self, mock_save_password, mock_send_password_email):
-        partner_id = self.res_partner.search(
-            self.cursor,
-            self.uid,
-            [('vat', '=', 'ES48591264S')]
-        )
-
-        context = {'active_ids': partner_id}
-        wiz_id = self.wiz_o.create(self.cursor, self.uid, {}, context=context)
-
-        def save_password(cursor, uid, partner_id, password):
-            raise FailSavePassword('Error text')
-
-        mock_save_password.side_effect = save_password
-
-        self.wiz_o.action_create_change_password(self.cursor, self.uid, [wiz_id], context=context)
-
-        wiz = self.wiz_o.read(self.cursor, self.uid, [wiz_id])[0]
-
-        self.assertEqual(wiz['state'], 'done')
-        self.assertEqual(wiz['info'], '{}: \n {} ({})\n'.format(
-            'Error generant contrassenyes pels següents partners',
-            int(partner_id[0]),
-            'Error al guardar la contrasseya'
-            )
-        )
-        mock_send_password_email.assert_not_called()
 
     @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.send_password_email")
     @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
@@ -206,36 +177,6 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
 
     @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.send_password_email")
     @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
-    def test__action_create_change_password__multiple_partners__KO_cannot_save_password__even_partner_id_with_exception(self, mock_save_password, mock_send_password_email):
-        partner_ids = self.res_partner.search(
-            self.cursor,
-            self.uid,
-            [('active', '=', True)]
-        )
-
-        context = {'active_ids': partner_ids}
-        wiz_id = self.wiz_o.create(self.cursor, self.uid, {}, context=context)
-
-        def save_password(cursor, uid, partner_id, password):
-            if partner_id % 2 == 0:
-                raise FailSavePassword('Error text')
-            return True
-
-        mock_save_password.side_effect = save_password
-
-        self.wiz_o.action_create_change_password(self.cursor, self.uid, [wiz_id], context=context)
-
-        wiz = self.wiz_o.read(self.cursor, self.uid, [wiz_id])[0]
-
-        self.assertEqual(wiz['state'], 'done')
-        self.assertEqual(wiz['info'], '{}: \n {}'.format(
-            'Error generant contrassenyes pels següents partners',
-            ','.join(['{} ({})\n'.format(str(int(x)),'Error al guardar la contrasseya') for x in partner_ids if x % 2 == 0])
-            )
-        )
-
-    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.send_password_email")
-    @mock.patch("som_users.wizard.wizard_create_change_password.WizardCreateChangePassword.save_password")
     def test__action_create_change_password__KO_cannot_send_password_email__even_partner_id(self, mock_save_password, mock_send_password_email):
         partner_ids = self.res_partner.search(
             self.cursor,
@@ -265,18 +206,6 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
             )
         )
 
-    def test__save_password__OK(self):
-        partner_id = self.res_partner.search(
-            self.cursor,
-            self.uid,
-            [('vat', '=', 'ES48591264S')]
-        )
-        password = 'test-password'
-
-        result = self.wiz_o.save_password(self.cursor, self.uid, partner_id[0], password)
-
-        self.assertTrue(result)
-
     @mock.patch("tools.config.get")
     def test__save_password__KO_without_api_key(self, mock_config):
         partner_id = self.res_partner.search(
@@ -291,4 +220,4 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
 
         result = self.wiz_o.save_password(self.cursor, self.uid, partner_id[0], password)
 
-        self.assertEqual(result['code'], 'FailSavePassword')
+        self.assertFalse(result)

--- a/som_users/tests/test_wizard_create_change_password.py
+++ b/som_users/tests/test_wizard_create_change_password.py
@@ -206,3 +206,17 @@ class WizardCreateChangePasswordTests(testing.OOTestCase):
             ','.join(['{} ({})\n'.format(str(int(x)),"Error al generar/enviar l'email") for x in partner_ids if x % 2 == 0])
             )
         )
+
+    def test__save_password__OK(self):
+        partner_id = self.res_partner.search(
+            self.cursor,
+            self.uid,
+            [('vat', '=', 'ES48591264S')]
+        )
+        context = {'active_ids': partner_id}
+        # wiz_id = self.wiz_o.create(self.cursor, self.uid, {}, context=context)
+        password = 'test-password'
+
+        result = self.wiz_o.save_password(self.cursor, self.uid, partner_id, password)
+
+        self.assertTrue(result)

--- a/som_users/wizard/__init__.py
+++ b/som_users/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard_create_change_password

--- a/som_users/wizard/__init__.py
+++ b/som_users/wizard/__init__.py
@@ -1,1 +1,1 @@
-from . import wizard_create_change_password
+import wizard_create_change_password

--- a/som_users/wizard/wizard_create_change_password.py
+++ b/som_users/wizard/wizard_create_change_password.py
@@ -35,8 +35,7 @@ class WizardCreateChangePassword(osv.osv_memory):
 
     def generatePassword(self):
         # Generate a list of random characters
-        import pudb; pu.db
-        characters = [random.choice(string.ascii_letters + string.digits) for _ in range(10)]
+        characters = [random.choice(string.ascii_letters + string.digits) for _ in range(8)]
         characters += [random.choice(string.punctuation) for _ in range(2)]
 
         # Shuffle the list of characters
@@ -107,7 +106,7 @@ class WizardCreateChangePassword(osv.osv_memory):
         start_key = 'generated_ov_password='
         end_key = '(generated_ov_password)\n'
 
-        new_comment = '{}{}{}\n'.format(start_key, password, end_key)
+        new_comment = '{}{}{}'.format(start_key, password, end_key)
 
         if comment:
             if start_key in comment:

--- a/som_users/wizard/wizard_create_change_password.py
+++ b/som_users/wizard/wizard_create_change_password.py
@@ -43,7 +43,7 @@ class WizardCreateChangePassword(osv.osv_memory):
         # Return the shuffled list of characters as a string
         return ''.join(characters)
 
-    def send_password_email(self, cursor, uid, partner):
+    def send_password_email(self, cursor, uid, partner, context=None):
         ir_model_data = self.pool.get('ir.model.data')
         power_email_tmpl_obj = self.pool.get('poweremail.templates')
 
@@ -100,7 +100,7 @@ class WizardCreateChangePassword(osv.osv_memory):
         except Exception as e:
             return False
 
-    def add_password_to_partner_comment(self, cursor, uid, partner_id, password):
+    def add_password_to_partner_comment(self, cursor, uid, partner_id, password, context=None):
         partner_o = self.pool.get("res.partner")
         comment = partner_o.read(cursor, uid, partner_id, ['comment'])['comment']
         start_key = 'generated_ov_password='
@@ -134,7 +134,7 @@ class WizardCreateChangePassword(osv.osv_memory):
             password = self.generatePassword()
             result = self.save_password(cursor, uid, partner_id, password)
             if not result:
-                info = "{} ({})\n".format(str(int(partner_id)),'Error al guardar la contraseya')
+                info = "{} ({})\n".format(str(int(partner_id)),'Error al guardar la contrasenya')
                 error_info.append(info)
                 continue
             self.add_password_to_partner_comment(cursor, uid, partner_id, password)

--- a/som_users/wizard/wizard_create_change_password.py
+++ b/som_users/wizard/wizard_create_change_password.py
@@ -10,7 +10,7 @@ from som_users.exceptions import FailSendEmail
 
 class WizardCreateChangePassword(osv.osv_memory):
 
-    """Classe per gestionar el canvi de contrassenya
+    """Classe per gestionar el canvi de contrasenya
     """
 
     _name = "wizard.create.change.password"
@@ -23,7 +23,7 @@ class WizardCreateChangePassword(osv.osv_memory):
         active_ids = context.get('active_ids')
 
         info = '{} ({}): \n{}'.format(
-            'Es generarant contrassenyes pels següents partners',
+            'Es generarant contrasenyes pels següents partners',
             len(active_ids),
             '\n'.join([partner_obj.read(cursor, uid, x, ['name'])['name'] for x in active_ids])
             )
@@ -128,13 +128,14 @@ class WizardCreateChangePassword(osv.osv_memory):
         partner_ids = context.get("active_ids")
         partner_o = self.pool.get("res.partner")
 
+        import pudb; pu.db
         error_info = []
         for partner_id in partner_ids:
             partner = partner_o.browse(cursor, uid, partner_id)
             password = self.generatePassword()
             result = self.save_password(cursor, uid, partner_id, password)
             if not result:
-                info = "{} ({})\n".format(str(int(partner_id)),'Error al guardar la contrasseya')
+                info = "{} ({})\n".format(str(int(partner_id)),'Error al guardar la contraseya')
                 error_info.append(info)
                 continue
             self.add_password_to_partner_comment(cursor, uid, partner_id, password)
@@ -151,11 +152,11 @@ class WizardCreateChangePassword(osv.osv_memory):
 
         if error_info:
             values['info'] = "{}: \n {}".format(
-                'Error generant contrassenyes pels següents partners',
+                'Error generant contrasenyes pels següents partners',
                 ','.join([x for x in error_info])
             )
         else:
-            values['info'] = "{}".format('Contrassenyes generades')
+            values['info'] = "{}".format('Contrasenyes generades')
 
         self.write(cursor, uid, ids, values)
         return True

--- a/som_users/wizard/wizard_create_change_password.py
+++ b/som_users/wizard/wizard_create_change_password.py
@@ -128,7 +128,6 @@ class WizardCreateChangePassword(osv.osv_memory):
         partner_ids = context.get("active_ids")
         partner_o = self.pool.get("res.partner")
 
-        import pudb; pu.db
         error_info = []
         for partner_id in partner_ids:
             partner = partner_o.browse(cursor, uid, partner_id)

--- a/som_users/wizard/wizard_create_change_password.py
+++ b/som_users/wizard/wizard_create_change_password.py
@@ -111,7 +111,7 @@ class WizardCreateChangePassword(osv.osv_memory):
         return True
 
     @www_entry_point(
-        expected_exceptions=[FailSavePassword, FailSendEmail]
+        expected_exceptions=FailSendEmail
     )
     def action_create_change_password(self, cursor, uid, ids, context=None):
         if context is None:
@@ -124,15 +124,12 @@ class WizardCreateChangePassword(osv.osv_memory):
         for partner_id in partner_ids:
             partner = partner_o.browse(cursor, uid, partner_id)
             password = self.generatePassword()
-            try:
+            result = self.save_password(cursor, uid, partner_id, password)
+            if not result or result['code'] == 'FailSavePassword':
                 info = "{} ({})\n".format(str(int(partner_id)),'Error al guardar la contrasseya')
-                saved = self.save_password(cursor, uid, partner_id, password)
-                if not saved:
-                    error_info.append(info)
-                    continue
-            except FailSavePassword as e:
                 error_info.append(info)
                 continue
+
             try:
                 self.send_password_email(cursor, uid, partner)
             except FailSendEmail as e:

--- a/som_users/wizard/wizard_create_change_password.py
+++ b/som_users/wizard/wizard_create_change_password.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+from osv import osv, fields
+import random
+import string
+import requests
+import json
+
+from som_users.decorators import www_entry_point
+from som_users.exceptions import FailSendEmail
+
+class WizardCreateChangePassword(osv.osv_memory):
+
+    """Classe per gestionar el canvi de contrassenya
+    """
+
+    _name = "wizard.create.change.password"
+
+    def generatePassword(self):
+        # Generate a list of random characters
+        characters = [random.choice(string.ascii_letters + string.digits + string.punctuation) for _ in range(10)]
+        # Shuffle the list of characters
+        random.shuffle(characters)
+        # Return the shuffled list of characters as a string
+        return ''.join(characters)
+
+    @www_entry_point(
+        expected_exceptions=FailSendEmail
+    )
+    def send_password_email(self, cursor, uid, partner):
+        ir_model_data = self.pool.get('ir.model.data')
+        power_email_tmpl_obj = self.pool.get('poweremail.templates')
+
+        template_id = ir_model_data.get_object_reference(
+            cursor, uid, 'som_users', 'email_create_change_password'
+        )[1]
+        template = power_email_tmpl_obj.read(cursor, uid, template_id)
+
+        account_obj = self.pool.get('poweremail.core_accounts')
+
+        email_from = False
+        email_account_id = 'info@somenergia.coop'
+        if template.get('enforce_from_account', False):
+            email_from = template.get('enforce_from_account')[0]
+        if not email_from:
+            email_from = account_obj.search(cursor, uid, [('email_id', '=', email_account_id)])[0]
+
+        try:
+            wiz_send_obj = self.pool.get('poweremail.send.wizard')
+            ctx = {
+                'active_ids': [partner.id],
+                'active_id': partner.id,
+                'template_id': template_id,
+                'src_model': 'res.partner',
+                'src_rec_ids': [partner.id],
+                'from': email_from,
+                'state': 'single',
+                'priority': '0',
+            }
+            params = {'state': 'single', 'priority': '0', 'from': ctx['from']}
+            wiz_id = wiz_send_obj.create(cursor, uid, params, ctx)
+            wiz_send_obj.send_mail(cursor, uid, [wiz_id], ctx)
+
+        except Exception as e:
+            raise FailSendEmail(e.message)
+
+        return True
+
+    def save_password(self, cursor, uid, partner_id, password):
+        partner_o = self.pool.get("res.partner")
+        nif = partner_o.read(cursor, uid, partner_id, ['vat'])['vat']
+
+        data = {
+            "username": nif,
+            "password": password
+        }
+
+        headers = {
+            'Accept': 'application/json',
+            'X-API-KEY': 'CACA'
+        }
+        url = "https://ov-representa.test.somenergia.coop/api/auth/provisioning"
+
+        r = requests.post(url, data=json.dumps(data), headers=headers)
+        res = json.loads(r.text)
+
+    def action_create_change_password(self, cursor, uid, ids, context=None):
+        if context is None:
+            context = {}
+
+        partner_ids = context.get("active_ids")
+        partner_o = self.pool.get("res.partner")
+        error_info = []
+        for partner_id in partner_ids:
+            partner = partner_o.browse(cursor, uid, partner_id)
+            password = self.generatePassword()
+            self.save_password(cursor, uid, partner_id, password)
+
+            if not self.send_password_email(cursor, uid, partner):
+                error_info.append(partner_id)
+
+        values = {
+            'state': 'done'
+        }
+
+        if error_info:
+            values['info'] = "{}: \n {}".format(
+                'Error generant contrassenyes pels següents partners',
+                ','.join([str(int(x)) for x in error_info])
+            )
+        else:
+            values['info'] = "{}\n".format('Contrassenyes generades')
+
+        self.write(cursor, uid, ids, values)
+        return True
+
+    _columns = {
+        'state': fields.char('State', size=16),
+        'info': fields.text('Info', size=4000),
+    }
+
+    _defaults = {
+        'state': lambda *a: 'init',
+    }
+
+WizardCreateChangePassword()

--- a/som_users/wizard/wizard_create_change_password.py
+++ b/som_users/wizard/wizard_create_change_password.py
@@ -16,6 +16,22 @@ class WizardCreateChangePassword(osv.osv_memory):
 
     _name = "wizard.create.change.password"
 
+
+    def default_get(self, cursor, uid, fields, context=None):
+        res = super(WizardCreateChangePassword, self).default_get(cursor, uid, fields, context)
+
+        active_ids = context.get('active_ids')
+
+        info = '{}: \n {}'.format(
+            'Es generarant contrassenyes pels següents partners',
+            ','.join([str(int(x)) for x in active_ids])
+            )
+
+        res.update({
+            'info': info,
+        })
+        return res
+
     def generatePassword(self):
         # Generate a list of random characters
         characters = [random.choice(string.ascii_letters + string.digits + string.punctuation) for _ in range(10)]

--- a/som_users/wizard/wizard_create_change_password.py
+++ b/som_users/wizard/wizard_create_change_password.py
@@ -20,15 +20,17 @@ class WizardCreateChangePassword(osv.osv_memory):
     def default_get(self, cursor, uid, fields, context=None):
         res = super(WizardCreateChangePassword, self).default_get(cursor, uid, fields, context)
 
+        partner_obj = self.pool.get('res.partner')
         active_ids = context.get('active_ids')
 
-        info = '{}: \n {}'.format(
+        info = '{} ({}): \n{}'.format(
             'Es generarant contrassenyes pels següents partners',
-            ','.join([str(int(x)) for x in active_ids])
+            len(active_ids),
+            '\n'.join([partner_obj.read(cursor, uid, x, ['name'])['name'] for x in active_ids])
             )
 
         res.update({
-            'info': info,
+            'initial_info': info,
         })
         return res
 
@@ -156,6 +158,7 @@ class WizardCreateChangePassword(osv.osv_memory):
     _columns = {
         'state': fields.char('State', size=16),
         'info': fields.text('Info', size=4000),
+        'initial_info': fields.text('Initial info', size=4000),
     }
 
     _defaults = {

--- a/som_users/wizard/wizard_create_change_password_view.xml
+++ b/som_users/wizard/wizard_create_change_password_view.xml
@@ -10,7 +10,7 @@
                     <field name="state" invisible="1"/>
                     <group colspan="4" attrs="{'invisible': [('state', '!=', 'init')]}">
                         <group colspan="4">
-                            <field name="info" editable="no" colspan="4" nolabel="1" height="200" width="400"/>
+                            <field name="initial_info" editable="no" nolabel="1" colspan="4" height="200" width="400"/>
                             <button icon="gtk-ok" name="action_create_change_password" string="Crear/Canviar" type="object"/>
                             <button special="cancel" string="Cancel·lar" icon="gtk-cancel"/>
                         </group>

--- a/som_users/wizard/wizard_create_change_password_view.xml
+++ b/som_users/wizard/wizard_create_change_password_view.xml
@@ -6,7 +6,7 @@
             <field name="model">wizard.create.change.password</field>
             <field name="type">form</field>
             <field name="arch" type="xml">
-                <form string="Generar o canviar contrassenya">
+                <form string="Generar o canviar contrasenya">
                     <field name="state" invisible="1"/>
                     <group colspan="4" attrs="{'invisible': [('state', '!=', 'init')]}">
                         <group colspan="4">
@@ -22,7 +22,7 @@
                 </form>
             </field>
         </record>      
-        <record id="action_generar_canviar_contrassenya" model="ir.actions.act_window">
+        <record id="action_generar_canviar_contrasenya" model="ir.actions.act_window">
             <field name="name">Generar o Canviar contrasenya OV</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">wizard.create.change.password</field>
@@ -31,11 +31,11 @@
             <field name="target">new</field>
             <field name="view_id" ref="view_create_change_password"/>
         </record>
-        <record id="ir_partner_contrassenya" model="ir.values">
+        <record id="ir_partner_contrasenya" model="ir.values">
             <field name="key2">client_action_multi</field>
             <field name="model">res.partner</field>
             <field name="name">Generar o Canviar contrasenya OV</field>
-            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_generar_canviar_contrassenya'))"/>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_generar_canviar_contrasenya'))"/>
             <field name="object" eval="1"/>
         </record>
     </data>

--- a/som_users/wizard/wizard_create_change_password_view.xml
+++ b/som_users/wizard/wizard_create_change_password_view.xml
@@ -23,7 +23,7 @@
             </field>
         </record>      
         <record id="action_generar_canviar_contrassenya" model="ir.actions.act_window">
-            <field name="name">Generar o Canviar contrassenya</field>
+            <field name="name">Generar o Canviar contrasenya OV</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">wizard.create.change.password</field>
             <field name="view_type">form</field>
@@ -34,7 +34,7 @@
         <record id="ir_partner_contrassenya" model="ir.values">
             <field name="key2">client_action_multi</field>
             <field name="model">res.partner</field>
-            <field name="name">Generar o Canviar contrassenya</field>
+            <field name="name">Generar o Canviar contrasenya OV</field>
             <field name="value" eval="'ir.actions.act_window,'+str(ref('action_generar_canviar_contrassenya'))"/>
             <field name="object" eval="1"/>
         </record>

--- a/som_users/wizard/wizard_create_change_password_view.xml
+++ b/som_users/wizard/wizard_create_change_password_view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>   
+        <record model="ir.ui.view" id="view_create_change_password">
+            <field name="name">wizard.create.change.password.form</field>
+            <field name="model">wizard.create.change.password</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Generar o canviar contrassenya">
+                    <field name="state" invisible="1"/>
+                    <group colspan="4" attrs="{'invisible': [('state', '!=', 'init')]}">
+                        <group colspan="4">
+                            <field name="info" colspan="4" width="400" readonly="1" nolabel="1"/>
+                            <button icon="gtk-ok" name="action_create_change_password" string="Crear/Canviar" type="object"/>
+                            <button special="cancel" string="Cancel·lar" icon="gtk-cancel"/>
+                        </group>
+                    </group>
+                    <group colspan="4" attrs="{'invisible': [('state', '!=', 'done')]}">
+                        <field name="info" colspan="4" width="400" readonly="1" nolabel="1"/>
+                        <button special="cancel" string="Tancar" icon="gtk-ok" colspan="4"/>
+                    </group>
+                </form>
+            </field>
+        </record>      
+        <record id="action_generar_canviar_contrassenya" model="ir.actions.act_window">
+            <field name="name">Generar o Canviar contrassenya</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">wizard.create.change.password</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="view_id" ref="view_create_change_password"/>
+        </record>
+        <record id="ir_partner_contrassenya" model="ir.values">
+            <field name="key2">client_action_multi</field>
+            <field name="model">res.partner</field>
+            <field name="name">Generar o Canviar contrassenya</field>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_generar_canviar_contrassenya'))"/>
+            <field name="object" eval="1"/>
+        </record>
+    </data>
+</openerp>

--- a/som_users/wizard/wizard_create_change_password_view.xml
+++ b/som_users/wizard/wizard_create_change_password_view.xml
@@ -10,13 +10,13 @@
                     <field name="state" invisible="1"/>
                     <group colspan="4" attrs="{'invisible': [('state', '!=', 'init')]}">
                         <group colspan="4">
-                            <field name="info" colspan="4" width="400" readonly="1" nolabel="1"/>
+                            <field name="info" editable="no" colspan="4" nolabel="1" height="200" width="400"/>
                             <button icon="gtk-ok" name="action_create_change_password" string="Crear/Canviar" type="object"/>
                             <button special="cancel" string="Cancel·lar" icon="gtk-cancel"/>
                         </group>
                     </group>
                     <group colspan="4" attrs="{'invisible': [('state', '!=', 'done')]}">
-                        <field name="info" colspan="4" width="400" readonly="1" nolabel="1"/>
+                        <field name="info" colspan="4" height="200" width="400" editable="no" nolabel="1"/>
                         <button special="cancel" string="Tancar" icon="gtk-ok" colspan="4"/>
                     </group>
                 </form>


### PR DESCRIPTION
## Description

A user wants to create or reset a password for a res_partner.

## Changes

- Action added to res_partner allowing the creation or reset of a password.
- The password is registered in the OV server available.
- The password is also stored in Notes then the email can recover the password.
- An email is sent to the OV user containing the password generated

## Deploy notes
X-API-KEY should be set in erp config  file.


