### PR TITLE
Fix contract installations relation

### DIFF
--- a/som_ov_installations/demo/giscere_instalacio_demo.xml
+++ b/som_ov_installations/demo/giscere_instalacio_demo.xml
@@ -14,7 +14,40 @@
         <record id="giscere_cil_0" model="giscere.cil">
             <field name="name">ES1234000000000001JK1F001</field>
             <field name="nv">Carrer Buenaventura Durruti</field>
-            <field name="pnp">666</field>
+            <field name="pnp">1</field>
+            <field name="aclarador">aclaridor</field>
+            <field name="codi_unitat_fisica">Unitat del poble</field>
+            <field name="id_municipi" ref="res_municipi_0"/>
+            <field name="id_provincia" ref="res_country_state_0"/>
+            <field name="distribuidora_id">1</field>
+            <field name="dp">08080</field>
+        </record>
+        <record id="giscere_cil_1" model="giscere.cil">
+            <field name="name">ES1234000000000001JK1F002</field>
+            <field name="nv">Carrer Buenaventura Durruti</field>
+            <field name="pnp">2</field>
+            <field name="aclarador">aclaridor</field>
+            <field name="codi_unitat_fisica">Unitat del poble</field>
+            <field name="id_municipi" ref="res_municipi_0"/>
+            <field name="id_provincia" ref="res_country_state_0"/>
+            <field name="distribuidora_id">1</field>
+            <field name="dp">08080</field>
+        </record>
+        <record id="giscere_cil_2" model="giscere.cil">
+            <field name="name">ES1234000000000001JK1F003</field>
+            <field name="nv">Carrer Buenaventura Durruti</field>
+            <field name="pnp">3</field>
+            <field name="aclarador">aclaridor</field>
+            <field name="codi_unitat_fisica">Unitat del poble</field>
+            <field name="id_municipi" ref="res_municipi_0"/>
+            <field name="id_provincia" ref="res_country_state_0"/>
+            <field name="distribuidora_id">1</field>
+            <field name="dp">08080</field>
+        </record>
+        <record id="giscere_cil_3" model="giscere.cil">
+            <field name="name">ES1234000000000001JK1F004</field>
+            <field name="nv">Carrer Buenaventura Durruti</field>
+            <field name="pnp">4</field>
             <field name="aclarador">aclaridor</field>
             <field name="codi_unitat_fisica">Unitat del poble</field>
             <field name="id_municipi" ref="res_municipi_0"/>
@@ -51,7 +84,7 @@
             <field name="codigo_ministerio">RE-00001</field>
             <field name="utm_y">0,80284</field>
             <field name="utm_x">41,54670</field>
-            <field name="cil">1</field>
+            <field name="cil" ref="giscere_cil_1"/>
             <field name="data_alta">2022-09-02</field>
             <field name="data_baixa"></field>
             <field name="descripcio">Description 1</field>
@@ -70,7 +103,7 @@
             <field name="codigo_ministerio">RE-00002</field>
             <field name="utm_y">0,80284</field>
             <field name="utm_x">41,54670</field>
-            <field name="cil">1</field>
+            <field name="cil" ref="giscere_cil_2"/>
             <field name="data_alta">2022-09-02</field>
             <field name="data_baixa"></field>
             <field name="descripcio">Description 2</field>
@@ -89,7 +122,7 @@
             <field name="codigo_ministerio">RE-00003</field>
             <field name="utm_y"></field>
             <field name="utm_x"></field>
-            <field name="cil">1</field>
+            <field name="cil" ref="giscere_cil_3"/>
             <field name="data_alta">2022-09-02</field>
             <field name="data_baixa"></field>
             <field name="descripcio">Description 3</field>
@@ -106,6 +139,75 @@
             <field name="acc_country_id">67</field>
         </record>
         <record id="giscere_polissa_0" model="giscere.polissa">
+            <field name="titular" ref="som_ov_users.res_partner_soci_legal"/>
+            <field name="renovacio_auto" eval="True"/>
+            <field name="comercialitzadora">1</field>
+            <field name="desvios">included</field>
+            <field name="representation_type">indirecta_cnmc</field>
+            <field name="contract_type">01</field>
+            <field name="name_auto" eval="True"/>
+            <field name="efecte_cartera">100</field>
+            <field name="active" eval="True"/>
+            <field name="name">100</field>
+            <field name="cil" ref="giscere_cil_0"/>
+            <field name="state">activa</field>
+            <field name="data_alta">2022-02-22</field>
+            <field name="data_firma_contracte">2022-02-23</field>
+            <field name="data_baixa"></field>
+            <field name="modcontractual_activa"></field>
+            <field name="mode_facturacio">index</field>
+            <field name="representant_fee">1.5</field>
+            <field name="desvios">included</field>
+            <field name="bank" ref="res_partner_bank_0"/>
+            <field name="efecte_cartera">100</field>
+        </record>
+        <record id="giscere_polissa_1" model="giscere.polissa">
+            <field name="titular" ref="som_ov_users.res_partner_soci_legal"/>
+            <field name="renovacio_auto" eval="True"/>
+            <field name="comercialitzadora">1</field>
+            <field name="desvios">included</field>
+            <field name="representation_type">indirecta_cnmc</field>
+            <field name="contract_type">01</field>
+            <field name="name_auto" eval="True"/>
+            <field name="efecte_cartera">100</field>
+            <field name="active" eval="True"/>
+            <field name="name">101</field>
+            <field name="cil" ref="giscere_cil_1"/>
+            <field name="state">activa</field>
+            <field name="data_alta">2022-02-22</field>
+            <field name="data_firma_contracte">2022-02-23</field>
+            <field name="data_baixa"></field>
+            <field name="modcontractual_activa"></field>
+            <field name="mode_facturacio">index</field>
+            <field name="representant_fee">1.5</field>
+            <field name="desvios">included</field>
+            <field name="bank" ref="res_partner_bank_0"/>
+            <field name="efecte_cartera">100</field>
+        </record>
+        <record id="giscere_polissa_2" model="giscere.polissa">
+            <field name="titular" ref="som_ov_users.res_partner_soci_legal"/>
+            <field name="renovacio_auto" eval="True"/>
+            <field name="comercialitzadora">1</field>
+            <field name="desvios">included</field>
+            <field name="representation_type">indirecta_cnmc</field>
+            <field name="contract_type">01</field>
+            <field name="name_auto" eval="True"/>
+            <field name="efecte_cartera">100</field>
+            <field name="active" eval="True"/>
+            <field name="name">102</field>
+            <field name="cil" ref="giscere_cil_2"/>
+            <field name="state">activa</field>
+            <field name="data_alta">2022-02-22</field>
+            <field name="data_firma_contracte">2022-02-23</field>
+            <field name="data_baixa"></field>
+            <field name="modcontractual_activa"></field>
+            <field name="mode_facturacio">index</field>
+            <field name="representant_fee">1.5</field>
+            <field name="desvios">included</field>
+            <field name="bank" ref="res_partner_bank_0"/>
+            <field name="efecte_cartera">100</field>
+        </record>
+        <record id="giscere_polissa_3" model="giscere.polissa">
             <field name="titular" ref="som_ov_users.res_partner_soci"/>
             <field name="renovacio_auto" eval="True"/>
             <field name="comercialitzadora">1</field>
@@ -115,8 +217,8 @@
             <field name="name_auto" eval="True"/>
             <field name="efecte_cartera">100</field>
             <field name="active" eval="True"/>
-            <field name="name">000</field>
-            <field name="cil">2</field>
+            <field name="name">103</field>
+            <field name="cil" ref="giscere_cil_3"/>
             <field name="state">activa</field>
             <field name="data_alta">2022-02-22</field>
             <field name="data_firma_contracte">2022-02-23</field>

--- a/som_ov_installations/exceptions.py
+++ b/som_ov_installations/exceptions.py
@@ -21,11 +21,17 @@ class InstallationsNotFound(SomInstallationsException):
             text="No installations found for this partner")
 
 
-class InstallationNotFound(SomInstallationsException):
-    def __init__(self):
-        super(InstallationNotFound, self).__init__(
-            text="The requested installation does not exist")
+class ContractWithoutInstallation(SomInstallationsException):
+    def __init__(self, contract_number):
+        super(ContractWithoutInstallation, self).__init__(
+            text="No installation found for contract '{}'".format(contract_number))
+        self.contract_number = contract_number
 
+    def to_dict(self):
+        return dict(
+            super(ContractWithoutInstallation, self).to_dict(),
+            contract_number=self.contract_number,
+        )
 
 class ContractNotExists(SomInstallationsException):
     def __init__(self):

--- a/som_ov_installations/exceptions.py
+++ b/som_ov_installations/exceptions.py
@@ -37,3 +37,23 @@ class ContractNotExists(SomInstallationsException):
     def __init__(self):
         super(ContractNotExists, self).__init__(
             text="Contract does not exist")
+
+class UnauthorizedAccess(SomInstallationsException):
+    def __init__(self, username, resource_type, resource_name):
+        super(UnauthorizedAccess, self).__init__(
+            text="User {username} cannot access the {resource_type} '{resource_name}'".format(
+                username=username,
+                resource_type=resource_type,
+                resource_name=resource_name,
+            ))
+        self.username = username
+        self.resource_type = resource_type
+        self.resource_name = resource_name
+
+    def to_dict(self):
+        return dict(
+            super(UnauthorizedAccess, self).to_dict(),
+            username=self.username,
+            resource_type=self.resource_type,
+            resource_name=self.resource_name,
+        )

--- a/som_ov_installations/som_ov_installations.py
+++ b/som_ov_installations/som_ov_installations.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 from osv import osv
+import logging
 
 from som_ov_users.decorators import www_entry_point
 from som_ov_users.exceptions import PartnerNotExists
 
 from exceptions import (
-    InstallationNotFound,
+    ContractWithoutInstallation,
     InstallationsNotFound,
     ContractNotExists
 )
 
+logger = logging.getLogger(__name__)
 
 class SomOvInstallations(osv.osv_memory):
 
@@ -19,7 +21,7 @@ class SomOvInstallations(osv.osv_memory):
         expected_exceptions=(
             PartnerNotExists,
             InstallationsNotFound,
-            InstallationNotFound,
+            ContractWithoutInstallation,
             ContractNotExists
         )
     )
@@ -29,62 +31,40 @@ class SomOvInstallations(osv.osv_memory):
 
         users_obj = self.pool.get('som.ov.users')
         partner = users_obj.get_customer(cursor, uid, vat)
+        polissa_obj = self.pool.get('giscere.polissa')
         installation_obj = self.pool.get('giscere.instalacio')
         search_params = [
            ('titular','=', partner.id),
         ]
 
-        installation_ids = installation_obj.search(cursor, uid, search_params)
-        if not installation_ids:
+        contract_ids = polissa_obj.search(cursor, uid, search_params)
+        if not contract_ids:
             raise InstallationsNotFound()
 
-        installations = installation_obj.browse(cursor, uid, installation_ids)
+        contracts = polissa_obj.browse(cursor, uid, contract_ids)
 
         return [
             dict(
-                contract_number=self._get_contract_number(cursor, uid, partner.id),
-                installation_name=installation.name,
+                contract_number=contract.name,
+                installation_name=installation_name,
             )
-            for installation in installations
+                for contract, installation_name in (
+                (contract, self._get_installation_name_by_cil(cursor, uid, contract.cil.id))
+                for contract in contracts
+            )
+            if installation_name
         ]
 
     @www_entry_point(
         expected_exceptions=(
-            InstallationNotFound,
+            ContractWithoutInstallation,
             ContractNotExists
         )
     )
-    def get_installation_details(self, cursor, uid, installation_name, context=None):
-        if context is None:
-            context = {}
-
-        installation_obj = self.pool.get('giscere.instalacio')
-        installation_search_params = [
-           ('name','=', installation_name),
-        ]
-        installation_id = installation_obj.search(cursor, uid, installation_search_params)
-        if not installation_id:
-            raise InstallationNotFound()
-
-        installation = installation_obj.browse(cursor, uid, installation_id)[0]
-        installation_details = dict(
-            contract_number=self._get_contract_number(cursor, uid, installation.titular.id),
-            name=installation.name,
-            address=installation.cil.direccio,
-            city=installation.cil.id_municipi.name,
-            postal_code=installation.cil.dp,
-            province=installation.cil.id_provincia.name,
-            coordinates=self._format_coordinates(installation),
-            technology=installation.tecnologia,
-            cil=installation.cil.name,
-            rated_power=installation.potencia_nominal,
-            type=installation.tipo,
-            ministry_code=installation.codigo_ministerio,
-        )
-
+    def get_installation_details(self, cursor, uid, contract_number, context=None):
         polissa_obj = self.pool.get('giscere.polissa')
         contract_search_params = [
-           ('name','=', self._get_contract_number(cursor, uid, installation.titular.id)),
+           ('name','=', contract_number),
         ]
         contract_id = polissa_obj.search(cursor, uid, contract_search_params)
         if not contract_id:
@@ -102,10 +82,35 @@ class SomOvInstallations(osv.osv_memory):
             status=contract.state,
         )
 
+        installation_obj = self.pool.get('giscere.instalacio')
+        installation_search_params = [
+           ('cil','=', contract.cil.id),
+        ]
+        installation_id = installation_obj.search(cursor, uid, installation_search_params)
+        if not installation_id:
+            raise ContractWithoutInstallation(contract_number)
+
+        installation = installation_obj.browse(cursor, uid, installation_id)[0]
+        installation_details = dict(
+            contract_number=contract_number,
+            name=installation.name,
+            address=installation.cil.direccio,
+            city=installation.cil.id_municipi.name,
+            postal_code=installation.cil.dp,
+            province=installation.cil.id_provincia.name,
+            coordinates=self._format_coordinates(installation),
+            technology=installation.tecnologia,
+            cil=installation.cil.name,
+            rated_power=installation.potencia_nominal,
+            type=installation.tipo,
+            ministry_code=installation.codigo_ministerio,
+        )
+
         return dict(
             installation_details=installation_details,
             contract_details=contract_details
         )
+
 
     def _format_coordinates(self, installation):
         coordinates = None
@@ -130,6 +135,17 @@ class SomOvInstallations(osv.osv_memory):
             raise ContractNotExists()
         contract = polissa_obj.browse(cursor, uid, contract_id)[0]
         return contract.name
-
+ 
+    def _get_installation_name_by_cil(self, cursor, uid, cil_id):
+        installation_obj = self.pool.get('giscere.instalacio')
+        search_params = [
+           ('cil','=', cil_id),
+        ]
+        installation_ids = installation_obj.search(cursor, uid, search_params)
+        installations = installation_obj.read(cursor, uid, installation_ids, ['name'])
+        if not installations:
+            logger.error('No installation with this cil {}'.format(cil_id))
+            return None
+        return installations[0]['name']
 
 SomOvInstallations()

--- a/som_ov_installations/som_ov_installations.py
+++ b/som_ov_installations/som_ov_installations.py
@@ -21,8 +21,6 @@ class SomOvInstallations(osv.osv_memory):
         expected_exceptions=(
             PartnerNotExists,
             InstallationsNotFound,
-            ContractWithoutInstallation,
-            ContractNotExists
         )
     )
     def get_installations(self, cursor, uid, vat, context=None):

--- a/som_ov_installations/tests/test_som_installations.py
+++ b/som_ov_installations/tests/test_som_installations.py
@@ -121,8 +121,9 @@ class SomInstallationsTests(testing.OOTestCase):
 
     def test__get_installation_details__base(self):
         contract_number = '101'
+        vat = self.legal_vat
 
-        result = self.installation.get_installation_details(self.cursor, self.uid, contract_number)
+        result = self.installation.get_installation_details(self.cursor, self.uid, vat, contract_number)
 
         expected_result = dict(
             installation_details=dict(
@@ -154,10 +155,10 @@ class SomInstallationsTests(testing.OOTestCase):
 
     def test__get_installation_details__contract_not_exists(self):
         contract_number = 'non_existing_contract_number'
+        vat = self.legal_vat
 
-        result = self.installation.get_installation_details(self.cursor, self.uid, contract_number)
+        result = self.installation.get_installation_details(self.cursor, self.uid, vat, contract_number)
 
-        self.assertEqual(result['code'], 'ContractNotExists')
         self.assertEqual(result, dict(
             code='ContractNotExists',
             error='Contract does not exist',
@@ -171,8 +172,9 @@ class SomInstallationsTests(testing.OOTestCase):
         installation_obj.unlink(self.cursor, self.uid, [installation_id])
 
         contract_number = '101'
+        vat = self.legal_vat
 
-        result = self.installation.get_installation_details(self.cursor, self.uid, contract_number)
+        result = self.installation.get_installation_details(self.cursor, self.uid, vat, contract_number)
 
         self.assertEqual(result, dict(
             code='ContractWithoutInstallation',
@@ -183,12 +185,30 @@ class SomInstallationsTests(testing.OOTestCase):
 
     def test__get_installation_details__coordinates_are_empty(self):
         contract_number = self.no_coordinates__contract_number
+        vat = self.base_vat
 
-        result = self.installation.get_installation_details(self.cursor, self.uid, contract_number)
+        result = self.installation.get_installation_details(self.cursor, self.uid, vat, contract_number)
 
         expected_coordinates = None
         self.assertEqual(expected_coordinates, result['installation_details']['coordinates'])
 
-    #def test_get_installation_details__other_people_installation
-    #def test_get_installation_details__other_people_installation
+    def test__get_installation_details__not_owner(self):
+        contract_number = '101' # belongs to legal_vat
+        vat = self.base_vat
+
+        result = self.installation.get_installation_details(self.cursor, self.uid, vat, contract_number)
+
+        self.assertEqual(result, dict(
+            code='UnauthorizedAccess',
+            error="User {vat} cannot access the Contract '{contract_number}'".format(
+                vat=vat,
+                contract_number=contract_number
+            ),
+            username=vat,
+            resource_type="Contract",
+            resource_name=contract_number,
+            trace=result.get('trace', "TRACE IS MISSING"),
+        ))
+
+
     #def test_get_installations___inactive_contracts_included_same_installation

--- a/som_ov_users/tests/test_som_ov_users.py
+++ b/som_ov_users/tests/test_som_ov_users.py
@@ -29,8 +29,7 @@ class SomUsersTests(testing.OOTestCase):
         self.txn.stop()
 
     def reference(self, module, id):
-        ir_model_data_obj = self.pool.get("ir.model.data")
-        return ir_model_data_obj.get_object_reference(
+        return self.imd.get_object_reference(
             self.cursor, self.uid, module, id,
         )[1]
 


### PR DESCRIPTION
## Description

Fixes how installations and contracts are queried and related

## Changes

- Installation/Contract details are queried by contract number not by installation name which is non-unique
- Relation between Contract and Installation is stablished by the CIL not by the "titular".
- SECURITY: Installation details require a username to check whether it has access or not.

## Observations

- BREAKING CHANGES: installation_details signature (username, contract_number) -> (installation_name)

## Please, review

- It works with UI

## How to check the new features

- Use the UI to exercise it

## Deploy notes

None
